### PR TITLE
Ajout d'un pom, afin de pouvoir produire du html l'aide de maven

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 *.pdf
 *.htm
 *.html
+*.iml
+.idea
+target

--- a/README.md
+++ b/README.md
@@ -6,3 +6,9 @@ Apache Maven (le livre)
 Pearson ayant décidé d'arrêter l'exploitation de ce livre, Arnaud et moi-même avons décidé de récupérer nos droits et de le publier pour qu'il soit accessible gratuitement à tous, et - sait on jamais - vive un second souffle avec l'aide de contributeurs bénévoles.
 
 License : [Creative-commons CC BY-SA 4.0](http://creativecommons.org/licenses/by-nc-sa/4.0/deed.fr)
+
+compile
+=======
+
+Pour produire les chapitres au format html, il suffit de lancer ```mvn clean compile```, le résultat est disponible sous ```target/html```
+

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>fr.loof</groupId>
+	<artifactId>apache-maven-book</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>2.6</version>
+				<executions>
+					<execution>
+						<id>copy-resources</id>
+						<!-- here the phase you need -->
+						<phase>validate</phase>
+						<goals>
+							<goal>copy-resources</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${basedir}/target/html/images/illustrations</outputDirectory>
+							<resources>
+								<resource>
+									<directory>illustrations</directory>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.asciidoctor</groupId>
+				<artifactId>asciidoctor-maven-plugin</artifactId>
+				<version>0.1.4</version>
+				<executions>
+					<execution>
+						<id>output-html</id>
+						<phase>compile</phase>
+						<goals>
+							<goal>process-asciidoc</goal>
+						</goals>
+						<configuration>
+							<sourceDirectory>${basedir}</sourceDirectory>
+							<outputDirectory>target/html</outputDirectory>
+							<backend>html</backend>
+							<doctype>book</doctype>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>


### PR DESCRIPTION
Y a plus qu'à faire mvn clean compile pour produire le html.

Et puis un bouquin sur maven sans pom.xml, ça le fait pas :)
