### PR TITLE
Fix problem on pom.xml (configuration missing)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
 						<goals>
 							<goal>process-asciidoc</goal>
 						</goals>
+						<configuration>
 							<outputDirectory>target/html</outputDirectory>
 							<backend>html</backend>
 							<doctype>book</doctype>


### PR DESCRIPTION
La balise configuration est manquante et génère une erreur de génération.
