### PR TITLE
Ajout d'un fichier de configuration pour la compilation avec asciidoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Build
 
 Pour produire les chapitres au format html, utilisez la configuration par défaut d'AsciiDoc
 
-    asciidoc maven.adoc
+    asciidoc -f asciidoc_maven.conf maven.adoc
   
 Nous étudions la génération d'un PDF et d'un format ePub.
 Un build maven est également à votre disposition si vous y tennez vraiment :)  

--- a/asciidoc_maven.conf
+++ b/asciidoc_maven.conf
@@ -1,0 +1,614 @@
+#
+# asciidoc.conf
+#
+# Asciidoc global configuration file.
+# Contains backend independent configuration settings that are applied to all
+# AsciiDoc documents.
+#
+
+[miscellaneous]
+tabsize=8
+textwidth=70
+newline=\r\n
+
+[attributes]
+backend-alias-html=xhtml11
+backend-alias-docbook=docbook45
+toclevels=2
+sectids=
+iconsdir=./images/icons
+encoding=UTF-8
+# Uncomment to use xhtml11 quirks mode CSS.
+#quirks=
+# Uncomment to use the Pygments source highlighter instead of GNU highlighter.
+#pygments=
+# Uncomment to use deprecated quote attributes.
+#deprecated-quotes=
+empty=
+sp=" "
+# Attribute and AttributeList element patterns.
+attributeentry-pattern=^:(?P<attrname>\w[^.]*?)(\.(?P<attrname2>.*?))?:(\s+(?P<attrvalue>.*))?$
+attributelist-pattern=(?u)(^\[\[(?P<id>[\w_:][\w_:.-]*)(,(?P<reftext>.*?))?\]\]$)|(^\[(?P<attrlist>.*)\]$)
+# Substitution attributes for escaping AsciiDoc processing.
+amp=&
+lt=<
+gt=>
+brvbar=|
+nbsp=&#160;
+zwsp=&#8203;
+wj=&#8288;
+deg=&#176;
+backslash=\
+two-colons=::
+two-semicolons=;;
+# DEPRECATED: underscore attribute names.
+two_colons=::
+two_semicolons=;;
+# Left and right single and double quote characters.
+# See http://en.wikipedia.org/wiki/Non-English_usage_of_quotation_marks
+lsquo=&#8216;
+rsquo=&#8217;
+ldquo=&#8220;
+rdquo=&#8221;
+
+[titles]
+subs=specialcharacters,quotes,replacements,macros,attributes,replacements2
+# Double-line title pattern and underlines.
+sectiontitle=^(?P<title>.*?)$
+underlines="==","--","~~","^^","++"
+# Single-line title patterns.
+sect0=^= +(?P<title>[\S].*?)( +=)?$
+sect1=^== +(?P<title>[\S].*?)( +==)?$
+sect2=^=== +(?P<title>[\S].*?)( +===)?$
+sect3=^==== +(?P<title>[\S].*?)( +====)?$
+sect4=^===== +(?P<title>[\S].*?)( +=====)?$
+blocktitle=^\.(?P<title>([^.\s].*)|(\.[^.\s].*))$
+
+[specialcharacters]
+&=&amp;
+<=&lt;
+>=&gt;
+
+[quotes]
+# The order is important, quotes are processed in conf file order.
+**=#strong
+*=strong
+``|''=doublequoted
+'=emphasis
+`|'=singlequoted
+ifdef::no-inline-literal[]
+`=monospaced
+endif::no-inline-literal[]
+# +++ and $$ quoting is applied to the +++ and $$ inline passthrough
+# macros to allow quoted attributes to be used.
+# This trick only works with inline passthrough macros.
++++=#unquoted
+$$=#unquoted
+++=#monospaced
++=monospaced
+__=#emphasis
+_=emphasis
+\##=#unquoted
+\#=unquoted
+^=#superscript
+~=#subscript
+
+[specialwords]
+emphasizedwords=
+strongwords=
+monospacedwords=
+
+[replacements]
+# Replacements performed in order of configuration file entry.  The first entry
+# of each replacement pair performs the (non-escaped) replacement, the second
+# strips the backslash from the escaped replacement.
+
+# (C) Copyright (entity reference &copy;)
+(?<!\\)\(C\)=&#169;
+\\\(C\)=(C)
+
+# (R) registered trade mark (entity reference &reg;
+(?<!\\)\(R\)=&#174;
+\\\(R\)=(R)
+
+# (TM) Trademark (entity reference &trade;)
+(?<!\\)\(TM\)=&#8482;
+\\\(TM\)=(TM)
+
+# -- Spaced and unspaced em dashes (entity reference &mdash;).
+# Space on both sides is translated to thin space characters.
+(^-- )=&#8212;&#8201;
+(\n-- )|( -- )|( --\n)=&#8201;&#8212;&#8201;
+(\w)--(\w)=\1&#8212;\2
+\\--(?!-)=--
+
+# Replace vertical typewriter apostrophe with punctuation apostrophe.
+(\w)'(\w)=\1&#8217;\2
+(\w)\\'(\w)=\1'\2
+
+# ... Ellipsis (entity reference &hellip;)
+(?<!\\)\.\.\.=&#8230;
+\\\.\.\.=...
+
+# Arrows from the Arrows block of Unicode.
+# -> right arrow
+(?<!\\)-&gt;=&#8594;
+\\-&gt;=-&gt;
+# => right double arrow
+(?<!\\)\=&gt;=&#8658;
+\\\=&gt;==&gt;
+# <- left arrow
+(?<!\\)&lt;-=&#8592;
+\\&lt;-=&lt;-
+# <= left double arrow
+(?<!\\)&lt;\==&#8656;
+\\&lt;\==&lt;=
+
+# Arbitrary entity references.
+(?<!\\)&amp;([:_#a-zA-Z][:_.\-\w]*?;)=&\1
+\\(&amp;[:_#a-zA-Z][:_.\-\w]*?;)=\1
+
+#-----------
+# Paragraphs
+#-----------
+[paradef-default]
+delimiter=(?s)(?P<text>\S.*)
+posattrs=style
+style=normal
+template::[paragraph-styles]
+
+[paradef-literal]
+delimiter=(?s)(?P<text>\s+.*)
+options=listelement
+posattrs=style
+style=literal
+template::[paragraph-styles]
+
+[paradef-admonition]
+delimiter=(?s)^\s*(?P<style>NOTE|TIP|IMPORTANT|WARNING|CAUTION):\s+(?P<text>.+)
+template::[paragraph-styles]
+
+[paragraph-styles]
+normal-style=template="paragraph"
+verse-style=template="verseparagraph",posattrs=["style","attribution","citetitle"]
+quote-style=template="quoteparagraph",posattrs=["style","attribution","citetitle"]
+literal-style=template="literalparagraph",subs=["verbatim"]
+listing-style=template="listingparagraph",subs=["verbatim"]
+NOTE-style=template="admonitionparagraph",name="note",caption="{note-caption}"
+TIP-style=template="admonitionparagraph",name="tip",caption="{tip-caption}"
+IMPORTANT-style=template="admonitionparagraph",name="important",caption="{important-caption}"
+WARNING-style=template="admonitionparagraph",name="warning",caption="{warning-caption}"
+CAUTION-style=template="admonitionparagraph",name="caution",caption="{caution-caption}"
+
+[literalparagraph]
+template::[literalblock]
+
+[verseparagraph]
+template::[verseblock]
+
+[quoteparagraph]
+template::[quoteblock]
+
+[listingparagraph]
+template::[listingblock]
+
+[macros]
+#--------------
+# Inline macros
+#--------------
+# Backslash prefix required for escape processing.
+# (?s) re flag for line spanning.
+
+# Macros using default syntax.
+(?su)(?<!\w)[\\]?(?P<name>http|https|ftp|file|irc|mailto|callto|image|link|anchor|xref|indexterm):(?P<target>\S*?)\[(?P<attrlist>.*?)\]=
+
+# These URL types don't require any special attribute list formatting.
+(?su)(?<!\S)[\\]?(?P<name>http|https|ftp|file|irc):(?P<target>//[^\s<>]*[\w/])=
+# Allow a leading parenthesis and square bracket.
+(?su)(?<\=[([])[\\]?(?P<name>http|https|ftp|file|irc):(?P<target>//[^\s<>]*[\w/])=
+# Allow <> brackets.
+(?su)[\\]?&lt;(?P<name>http|https|ftp|file|irc):(?P<target>//[^\s<>]*[\w/])&gt;=
+
+# Email addresses don't require special attribute list formatting.
+# The before ">: and after "< character exclusions stop multiple substitution.
+(?su)(?<![">:\w._/-])[\\]?(?P<target>\w[\w._-]*@[\w._-]*\w)(?!["<\w_-])=mailto
+
+# Allow footnote macros hard up against the preceding word so the footnote mark
+# can be placed against the noted text without an intervening space
+# (http://groups.google.com/group/asciidoc/browse_frm/thread/e1dcb7ee0efc17b5).
+(?su)[\\]?(?P<name>footnote|footnoteref):(?P<target>\S*?)\[(?P<attrlist>.*?)\]=
+
+# Anchor: [[[id]]]. Bibliographic anchor.
+(?su)[\\]?\[\[\[(?P<attrlist>[\w_:][\w_:.-]*?)\]\]\]=anchor3
+# Anchor: [[id,xreflabel]]
+(?su)[\\]?\[\[(?P<attrlist>[\w"_:].*?)\]\]=anchor2
+# Link: <<id,text>>
+(?su)[\\]?&lt;&lt;(?P<attrlist>[\w"_:].*?)&gt;&gt;=xref2
+
+ifdef::asciidoc7compatible[]
+# Index term: ++primary,secondary,tertiary++
+(?su)(?<!\S)[\\]?\+\+(?P<attrlist>[^+].*?)\+\+(?!\+)=indexterm
+# Index term: +primary+
+# Follows ++...++ macro otherwise it will match them.
+(?<!\S)[\\]?\+(?P<attrlist>[^\s\+][^+].*?)\+(?!\+)=indexterm2
+endif::asciidoc7compatible[]
+
+ifndef::asciidoc7compatible[]
+# Index term: (((primary,secondary,tertiary)))
+(?su)(?<!\()[\\]?\(\(\((?P<attrlist>[^(].*?)\)\)\)(?!\))=indexterm
+# Index term: ((primary))
+# Follows (((...))) macro otherwise it will match them.
+(?<!\()[\\]?\(\((?P<attrlist>[^\s\(][^(].*?)\)\)(?!\))=indexterm2
+endif::asciidoc7compatible[]
+
+# Callout
+[\\]?&lt;(?P<index>\d+)&gt;=callout
+
+# Passthrough macros.
+(?su)[\\]?(?P<name>pass):(?P<subslist>\S*?)\[(?P<passtext>.*?)(?<!\\)\]=[]
+
+# Triple-plus and double-dollar inline passthroughs.
+(?su)[\\]?\+\+\+(?P<passtext>.*?)\+\+\+=pass[]
+(?su)[\\]?\$\$(?P<passtext>.*?)\$\$=pass[specialcharacters]
+
+# Inline literal.
+ifndef::no-inline-literal[]
+(?su)(?<![`\w])([\\]?`(?P<passtext>[^`\s]|[^`\s].*?\S)`)(?![`\w])=literal[specialcharacters]
+endif::no-inline-literal[]
+
+# Inline comment.
+(?mu)^[\\]?//(?P<passtext>[^/].*|)$=comment[specialcharacters]
+
+# Default (catchall) inline macro is not implemented so there is no ambiguity
+# with previous definition that could result in double substitution of escaped
+# references.
+#(?su)[\\]?(?P<name>\w(\w|-)*?):(?P<target>\S*?)\[(?P<passtext>.*?)(?<!\\)\]=
+
+#-------------
+# Block macros
+#-------------
+# Macros using default syntax.
+(?u)^(?P<name>image|unfloat)::(?P<target>\S*?)(\[(?P<attrlist>.*?)\])$=#
+
+# Passthrough macros.
+(?u)^(?P<name>pass)::(?P<subslist>\S*?)(\[(?P<passtext>.*?)\])$=#
+
+^'{3,}$=#ruler
+^<{3,}$=#pagebreak
+^//(?P<passtext>[^/].*|)$=#comment[specialcharacters]
+
+[unfloat-blockmacro]
+# Implemented in HTML backends.
+
+#-----------------
+# Delimited blocks
+#-----------------
+[blockdef-comment]
+delimiter=^/{4,}$
+options=skip
+
+[blockdef-sidebar]
+delimiter=^\*{4,}$
+template=sidebarblock
+options=sectionbody
+posattrs=style
+# DEPRECATED: Use Openblock instead.
+abstract-style=template="abstractblock"
+
+[blockdef-open]
+# A block without opening or closing tags.
+delimiter=^--$
+template=openblock
+options=sectionbody
+posattrs=style
+abstract-style=template="abstractblock"
+partintro-style=template="partintroblock"
+
+[blockdef-pass]
+delimiter=^\+{4,}$
+template=passblock
+# Default subs choosen for backward compatibility.
+subs=attributes,macros
+posattrs=style
+pass-style=template="passblock",subs=[]
+
+[blockdef-listing]
+delimiter=^-{20,}$
+template=listingblock
+subs=verbatim
+posattrs=style
+
+[blockdef-literal]
+delimiter=^\.{4,}$
+template=literalblock
+subs=verbatim
+posattrs=style
+listing-style=template="listingblock"
+# DEPRECATED: Use verse style on quote blocks instead.
+verse-style=template="verseblock",subs="normal"
+
+[blockdef-quote]
+delimiter=^_{4,}$
+subs=normal
+style=quote
+posattrs=style,attribution,citetitle
+quote-style=template="quoteblock",options=("sectionbody",)
+verse-style=template="verseblock"
+
+[blockdef-example]
+delimiter=^={4,}$
+template=exampleblock
+options=sectionbody
+posattrs=style
+NOTE-style=template="admonitionblock",name="note",caption="{note-caption}"
+TIP-style=template="admonitionblock",name="tip",caption="{tip-caption}"
+IMPORTANT-style=template="admonitionblock",name="important",caption="{important-caption}"
+WARNING-style=template="admonitionblock",name="warning",caption="{warning-caption}"
+CAUTION-style=template="admonitionblock",name="caution",caption="{caution-caption}"
+
+# For use by custom filters.
+# DEPRECATED: No longer used, a styled listing block (blockdef-listing) is preferable.
+[blockdef-filter]
+delimiter=^~{4,}$
+template=listingblock
+subs=none
+posattrs=style
+
+#-------
+# Lists
+#-------
+[listdef-bulleted]
+# - bullets.
+delimiter=^\s*- +(?P<text>.+)$
+posattrs=style
+type=bulleted
+tags=bulleted
+callout-style=tags="callout"
+bibliography-style=tags="bibliography"
+
+[listdef-bulleted1]
+# * bullets.
+template::[listdef-bulleted]
+delimiter=^\s*\* +(?P<text>.+)$
+
+[listdef-bulleted2]
+# ** bullets.
+template::[listdef-bulleted]
+delimiter=^\s*\*{2} +(?P<text>.+)$
+
+[listdef-bulleted3]
+# *** bullets.
+template::[listdef-bulleted]
+delimiter=^\s*\*{3} +(?P<text>.+)$
+
+[listdef-bulleted4]
+# **** bullets.
+template::[listdef-bulleted]
+delimiter=^\s*\*{4} +(?P<text>.+)$
+
+[listdef-bulleted5]
+# ***** bullets.
+template::[listdef-bulleted]
+delimiter=^\s*\*{5} +(?P<text>.+)$
+
+[listdef-arabic]
+# Arabic numbering.
+delimiter=^\s*(?P<index>\d+\.) +(?P<text>.+)$
+posattrs=style
+type=numbered
+tags=numbered
+style=arabic
+
+[listdef-loweralpha]
+# Lower alpha numbering.
+template::[listdef-arabic]
+delimiter=^\s*(?P<index>[a-z]\.) +(?P<text>.+)$
+style=loweralpha
+
+[listdef-upperalpha]
+# Upper alpha numbering.
+template::[listdef-arabic]
+delimiter=^\s*(?P<index>[A-Z]\.) +(?P<text>.+)$
+style=upperalpha
+
+[listdef-lowerroman]
+# Lower roman numbering.
+template::[listdef-arabic]
+delimiter=^\s*(?P<index>[ivx]+\)) +(?P<text>.+)$
+style=lowerroman
+
+[listdef-upperroman]
+# Upper roman numbering.
+template::[listdef-arabic]
+delimiter=^\s*(?P<index>[IVX]+\)) +(?P<text>.+)$
+style=upperroman
+
+[listdef-numbered1]
+# . numbering.
+template::[listdef-arabic]
+delimiter=^\s*\. +(?P<text>.+)$
+
+[listdef-numbered2]
+# .. numbering.
+template::[listdef-loweralpha]
+delimiter=^\s*\.{2} +(?P<text>.+)$
+
+[listdef-numbered3]
+# ... numbering.
+template::[listdef-lowerroman]
+delimiter=^\s*\.{3} +(?P<text>.+)$
+
+[listdef-numbered4]
+# .... numbering.
+template::[listdef-upperalpha]
+delimiter=^\s*\.{4} +(?P<text>.+)$
+
+[listdef-numbered5]
+# ..... numbering.
+template::[listdef-upperroman]
+delimiter=^\s*\.{5} +(?P<text>.+)$
+
+[listdef-labeled]
+# label:: item.
+delimiter=^\s*(?P<label>.*[^:])::(\s+(?P<text>.+))?$
+posattrs=style
+type=labeled
+tags=labeled
+vertical-style=tags="labeled"
+horizontal-style=tags="horizontal"
+glossary-style=tags="glossary"
+qanda-style=tags="qanda"
+
+[listdef-labeled2]
+# label;; item.
+template::[listdef-labeled]
+delimiter=^\s*(?P<label>.*[^;]);;(\s+(?P<text>.+))?$
+
+[listdef-labeled3]
+# label::: item.
+template::[listdef-labeled]
+delimiter=^\s*(?P<label>.*[^:]):{3}(\s+(?P<text>.+))?$
+
+[listdef-labeled4]
+# label:::: item.
+template::[listdef-labeled]
+delimiter=^\s*(?P<label>.*[^:]):{4}(\s+(?P<text>.+))?$
+
+[listdef-callout]
+posattrs=style
+delimiter=^<?(?P<index>\d*>) +(?P<text>.+)$
+type=callout
+tags=callout
+style=arabic
+
+# DEPRECATED: Old list syntax.
+[listdef-qanda]
+posattrs=style
+delimiter=^\s*(?P<label>.*\S)\?\?$
+type=labeled
+tags=qanda
+
+# DEPRECATED: Old list syntax.
+[listdef-bibliography]
+posattrs=style
+delimiter=^\+ +(?P<text>.+)$
+type=bulleted
+tags=bibliography
+
+# DEPRECATED: Old list syntax.
+[listdef-glossary]
+delimiter=^(?P<label>.*\S):-$
+posattrs=style
+type=labeled
+tags=glossary
+
+#-------
+# Tables
+#-------
+[tabledef-default]
+delimiter=^\|={3,}$
+posattrs=style
+template=table
+default-style=tags="default"
+verse-style=tags="verse"
+literal-style=tags="literal",subs=["specialcharacters"]
+emphasis-style=tags="emphasis"
+strong-style=tags="strong"
+monospaced-style=tags="monospaced"
+header-style=tags="header"
+asciidoc-style=tags="asciidoc",subs=[],filter='python "{asciidoc-file}" -b {backend} {asciidoc-args}{lang? -a "lang={lang}@"}{icons? -a icons -a "iconsdir={iconsdir}"}{imagesdir? -a "imagesdir={imagesdir}"}{data-uri? -a data-uri} -a "indir={indir}"{trace? -a "trace={trace}"} -s -'
+
+[tabledef-nested]
+# Same as [tabledef-default] but with different delimiter and separator.
+delimiter=^!={3,}$
+separator=((?<!\S)((?P<span>[\d.]+)(?P<op>[*+]))?(?P<align>[<\^>.]{,3})?(?P<style>[a-z])?)?!
+posattrs=style
+template=table
+verse-style=tags="verse"
+literal-style=tags="literal",subs=["specialcharacters"]
+emphasis-style=tags="emphasis"
+strong-style=tags="strong"
+monospaced-style=tags="monospaced"
+header-style=tags="header"
+asciidoc-style=tags="asciidoc",subs=[],filter='python "{asciidoc-file}" -b {backend} {asciidoc-args}{lang? -a "lang={lang}@"} -s -'
+
+#----------------------------------------
+# Common block and macro markup templates
+#----------------------------------------
+[comment-inlinemacro]
+# Outputs nothing.
+
+[comment-blockmacro]
+# Outputs nothing.
+
+[pass-blockmacro]
+{passtext}
+
+[pass-inlinemacro]
+template::[pass-blockmacro]
+
+[passblock]
+|
+
+[filter-image-blockmacro]
+# Synthesize missing target attribute for filter generated file names.
+# The tag split | ensures missing target file names are auto-generated
+# before the filter is executed, the remainder (the [image-blockmacro])
+# is excuted after the filter to ensure data URI encoding comes after
+# the image is created.
+{target%}{counter2:target-number}
+{target%}{set2:target:{docname}__{target-number}.png}
+|
+template::[image-blockmacro]
+
+[+docinfo]
+# Blank section to suppress missing template warning.
+
+#----------------------------------
+# Default special section templates
+#----------------------------------
+[abstract]
+template::[sect1]
+
+[colophon]
+template::[sect1]
+
+[dedication]
+template::[sect1]
+
+[preface]
+template::[sect1]
+
+[appendix]
+template::[sect1]
+
+[glossary]
+template::[sect1]
+
+[bibliography]
+template::[sect1]
+
+[index]
+template::[sect1]
+
+[synopsis]
+template::[sect1]
+
+#--------------------------------------------------------------------
+# Deprecated old table definitions.
+#
+
+[old_tabledef-default]
+fillchar=-
+format=fixed
+
+[old_tabledef-csv]
+fillchar=~
+format=csv
+
+[old_tabledef-dsv]
+fillchar=_
+format=dsv
+
+# End of deprecated old table definitions.
+#--------------------------------------------------------------------

--- a/maven.adoc
+++ b/maven.adoc
@@ -5,6 +5,8 @@ v3.0, 2014
 :doctype: book
 :icons: font
 :source-highlighter: highlightjs
+:lang: fr
+:encode: ISO-8859-1
 :imagesdir: illustrations
 :homepage: https://github.com/ndeloof/apache-maven-book/
 :desc: Ce livre est une introduction à Apache Maven. Originalement publié aux +
@@ -12,6 +14,7 @@ v3.0, 2014
 	   sous license Creative Commons 4.0 BY-NC-SA
 
 [preface]
+[[Preface_de_la_troisieme_edition]]
 = Préface de la troisième édition
 
 image:MangaNicolas.png[float="left"]
@@ -54,6 +57,7 @@ image:license.png[align="center"]
 _Nicolas de Loof_
 
 [preface]
+[[Preface_de_la_seconde_edition]]
 = Préface de la seconde édition
 
 image:MangaNicolas.png[float="left"]
@@ -249,7 +253,9 @@ quelques peu abscons utilisés dans cet ouvrage.
 
 = Partie 1
 [partintro]
-.Premiers pas avec Maven
+--
+Premiers pas avec Maven
+--
 
 == Chapitre 1 : Introduction
 
@@ -376,6 +382,7 @@ utilisateur du système Solaris, s'est souvent trouvé face à ce
 problème ; il lui propose d'utiliser un fichier de commande universel,
 basé sur l'outil Apache Ant.
 
+[[Les_fourmis_a_la_rescousse]]
 === Les fourmis à la rescousse
 
 Qu'est-ce que c'est que ce "Ant" ? Faisons un détour par Wikipédia pour
@@ -450,6 +457,8 @@ ensemble le développement de ce projet. Des complications commencent à
 ses habitudes "maison" et ses bonnes pratiques et voudrait les voir
 appliquées.
 
+
+[[Et_Maven_dans_tout_ca]]
 === Et Maven dans tout ça ?
 
 image:MangaJason.png[float="left"]
@@ -602,6 +611,7 @@ construit un fichier JAR, ce qu'on attendait de lui, mais il a également
 tenté de copier des "ressources" et d'exécuter des tests, ensemble de
 traitements que nous n'avons spécifiés nulle part !
 
+[[La_cle_du_mystere]]
 === La clé du mystère
 
 Interrogé sur le sujet, Jason nous livre la clé du mystère : Ant, make
@@ -632,6 +642,7 @@ en quoi un projet est différent de ce "scénario type" que de répéter
 invariablement des commandes très comparables d'un projet à l'autre.
 Maven exploite donc le concept très structurant de conventions.
 
+[[convention_plutot_que_configuration]]
 ==== Convention plutôt que configuration
 
 Notre pseudo-exemple réunissant les étapes "initialiser", "compiler",
@@ -686,6 +697,7 @@ n'avons plus besoin d'indiquer la moindre commande. Il nous suffit de
 décrire en quoi notre projet est différent de ce cas stéréotypé. Nous
 passons d'une approche programmatique à une solution déclarative.
 
+[[Decrire_plutot_que_programmer]]
 ==== Décrire plutôt que programmer
 
 Notre fichier pom.xml de Maven ne compte aucune commande de compilation
@@ -938,7 +950,7 @@ d'Ant ou de ses équivalents. Au cours des chapitres qui suivent, nous
 allons voir en quoi cette approche se généralise à toutes les tâches qui
 accompagnent la vie d'un projet.
 
-
+[[Au_dela_de_java.lang]]
 == Chapitre 2 : Au-delà de java.lang
 
 === Des JAR sous CVS
@@ -966,6 +978,7 @@ projet.
 Notre prototype ne déroge pas à cette "bonne idée" et possède comme tant
 d'autres un répertoire lib avec l'ensemble des bibliothèques utilisées.
 
+[[Quand_le_repertoire_lib_explose]]
 ==== Quand le répertoire lib explose
 
 La croissance de l'équipe nous permet de rapidement améliorer notre
@@ -1011,6 +1024,7 @@ peut être extrêmement complexe, car la remise en cause de la
 bibliothèque sera probablement la toute dernière hypothèse que nous
 évoquerons pour justifier un dysfonctionnement.
 
+[[Un_bogue_est_detecte]]
 ===== Un bogue est détecté
 
 Après quelques heures de tests et de recherche d'informations sur
@@ -1155,6 +1169,7 @@ existe de nombreuses exceptions pour des raisons historiques liées à la
 première mouture de Maven.
 ====
 
+[[Depot_de_bibliotheques]]
 ==== Dépôt de bibliothèques
 
 La configuration par défaut de Maven utilise le dépôt (ou _référentiel_)
@@ -1201,6 +1216,7 @@ de Maven.
 * Un fichier de métadonnées, propre à Maven comme son nom l'indique
 clairement.
 
+[[Avis_aux_amateurs_de_casse_tete]]
 === Avis aux amateurs de casse-tête
 
 Notre projet, issu d'un code antédiluvien auquel chacun est venu
@@ -1428,6 +1444,7 @@ commandes de construction du projet. Avec cette précision, jUnit ne sera
 pas inclus sur la liste des bibliothèques référencées par la commande de
 compilation. Maven aurait ainsi identifié notre bogue immédiatement.
 
+[[Une_arme_a_double_tranchant]]
 === Une arme à double tranchant
 
 La facilité avec laquelle Maven permet de marier les bibliothèques,
@@ -1567,6 +1584,7 @@ erreurs. Dans notre cas, nous voulons conserver commons-logging et
 exclure commons-logging-api, mais aucune solution automatique n'est
 possible.
 
+[[L_analyse_des_dependances]]
 ==== L'analyse des dépendances
 
 Avec le nombre de frameworks que nous avons intégrés à l'application, il
@@ -1629,6 +1647,7 @@ image:02-03.png[align="center"]
 
 Plugin Maven pour Eclipse.
 
+[[Depots_et_dependances]]
 ==== Dépôts et dépendances
 
 image:Maven3.png[Maven3,align="center"]
@@ -1711,6 +1730,7 @@ jcr-on-cassandra-1.8.0.10.pom>geek.org=
 
 Le compte-rendu de nos experts fournit l’explication.
 
+[[Depots_et_dependances_2]]
 ==== Dépôts et dépendances
 
 Maven utilise par défaut un dépôt nommé central, qui héberge un vaste
@@ -1772,6 +1792,7 @@ hasardeux. Nous allons voir maintenant comment il poursuit cet effort
 lorsque notre projet "dévie" progressivement de l'exemple si simple que
 nous avons utilisé pour l'instant.
 
+[[Etes_vous_pret_pour_Java_7]]
 === Êtes-vous prêt pour Java 7 ?
 
 Le prototype à l'origine de notre projet a été écrit il y a belle
@@ -1931,6 +1952,7 @@ Attention cependant, car le site web généré correspond généralement à la
 version en cours de développement du plugin, aussi soyez attentif à
 l'indication "@since" ajoutée à certains paramètres.
 
+[[Proprietes]]
 === Propriétés
 
 La modification du fonctionnement du plugin de compilation nous permet
@@ -2043,6 +2065,7 @@ suffit d'ajouter au projet le plugin X. L'approche déclarative de Maven
 économise la déclaration des opérations réalisées par le plugin et de la
 façon dont elles s'intègrent dans le projet.
 
+[[Ou_placer_les_source]]
 ==== Où placer les sources
 
 Nous l'avons déjà dit, les conventions de Maven sont un élément décisif
@@ -2133,6 +2156,7 @@ Cependant, nos sources Groovy ne sont pas prises en compte, et les
 traces d'exécution de la console ne laissent entendre aucun traitement
 particulier de ce langage. Nous avons dû brûler une étape…
 
+[[Plugin_et_taches]]
 ==== Plugin et tâches
 
 La notion de plugin permet à Maven d'isoler, dans un sous-projet dédié
@@ -2391,6 +2415,7 @@ image:03-05.png[align="center"]
 
 Cycle de vie du projet et plugins exécutés pour chaque phase.
 
+[[Generer_du_code]]
 === Générer du code
 
 Suite aux nombreuses évolutions que nous avons apportées, notre projet
@@ -3101,6 +3126,7 @@ dépendances transitive de Maven nous ouvre les portes d'outils de test
 et de simulation très avancés, avec une simplicité de mise en œuvre
 déconcertante.
 
+[[Le_developpement_pilote_par_les_tests]]
 ==== Le développement piloté par les tests
 
 Les tests automatisés que nous venons d'ajouter à notre projet nous
@@ -3219,6 +3245,7 @@ Maven participe à cette démarche par la place qu'il donne au test dans
 le cycle de vie du projet. Les tests vus par Maven sont des éléments de
 premier plan du projet.
 
+[[Pas_de_jar_sans_tests_reussis]]
 ==== Pas de JAR sans tests réussis
 
 Le passage des tests par Maven fait partie des phases standard de
@@ -3252,6 +3279,7 @@ auquel cas il pourra la présenter à son client à l'arrivée de son voyage
 d'affaires. C'est une option dangereuse si elle est trop utilisée et que
 nos tests automatisés ne soient plus exécutés.
 
+[[Reutiliser_notre_outillage_de_test]]
 ==== Réutiliser notre outillage de test
 
 Au fur et à mesure de l'écriture des tests, nous avons dû développer des
@@ -3370,6 +3398,7 @@ de Lukas.
 </project>
 -------------------------------------------------------------------------------
 
+[[L_integration_continue]]
 ==== L'intégration continue
 
 Nous l'avons vu, nos tests automatisés prennent toute leur valeur
@@ -3554,6 +3583,7 @@ tests sont au vert est autrement plus rassurant pour l'équipe que
 d'appliquer les derniers correctifs en espérant ne pas avoir introduit
 d'erreur à quelques heures de la livraison.
 
+[[Mettre_en_place_des_tests_d_integration]]
 == Chapitre 5 : Mettre en place des tests d'intégration
 
 Nous avons vu au fil des pages qui précèdent comment outiller notre
@@ -3703,6 +3733,7 @@ Widgets et autres ClickHandlers. L'option -P suivie des noms des profils
 séparés par une virgule permet d'activer à la demande les profils
 désirés par l'utilisateur.
 
+[[S_adapter_a_l_environnement]]
 ==== S'adapter à l'environnement
 
 Une autre utilisation des profils consiste à adapter la configuration
@@ -3792,6 +3823,7 @@ bibliothèque avec et sans mécanisme de débogage comme le propose le
 driver Oracle.
 ====
 
+[[desactiver_a_la_demande]]
 ==== Désactiver à la demande
 
 Un profil peut aussi être déclaré "actif par défaut", auquel cas on
@@ -3862,6 +3894,7 @@ effets indésirables si on introduit un nouveau profil sur un projet, car
 ceux qui étaient jusqu'ici "actifs par défaut" seront alors… désactivés.
 ====
 
+[[Tester_l_acces_a_une_base_de_donnees]]
 === Tester l'accès à une base de données
 
 image:MangaHerve.png[float="left"]
@@ -4157,6 +4190,7 @@ l'automatisation par Maven pour assembler notre application web,
 configurer un serveur d'application de test et démarrer le tout juste
 avant d'exécuter ce type de test.
 
+[[integration_continue_2]]
 ==== Intégration continue
 
 Le serveur d'intégration continue est utilisé pour l'instant pour
@@ -4367,6 +4401,7 @@ est un clin d'œil à cette aventure humaine qui montre un autre visage du
 développement open-source.
 --
 
+[[Gestion_avancee_des_dependances]]
 == Chapitre 6 : Gestion avancée des dépendances
 
 Notre projet commence à prendre une tournure "intéressante" du point de
@@ -4521,6 +4556,7 @@ pas strictement besoin, mais qui sait ?
 C'est une solution rapide, tout à fait légitime si nous disposons de la
 bibliothèque en question par un autre moyen.
 
+[[les_dependances_system]]
 ==== Les dépendances "System"
 
 Nous avons donc une solution pour le pilote Oracle ; cependant, chacun
@@ -4584,6 +4620,7 @@ peu contre-nature. Par ailleurs, si chaque projet qui utilise une base
 Oracle doit intégrer un répertoire lib, nous allons être témoins de la
 multiplication rapide des fichiers JAR sur nos postes de développement.
 
+[[Creer_son_propre_depot]]
 === Créer son propre dépôt
 
 image:MangaCarlos.png[float="left"]
@@ -4631,6 +4668,7 @@ utilisé pour configurer Maven. Le gestionnaire de dépôt Nexus peut même
 générer ce fichier avec les déclarations adéquates.
 ====
 
+[[controle_d_identite_vos_papiers_s_il_vous_plait]]
 ==== Contrôle d'identité, vos papiers s'il vous plaît !
 
 Le dépôt de bibliothèques ne contient pas seulement le fichier POM de
@@ -4662,6 +4700,7 @@ jusqu'à l'origine du problème aurait été bien délicat. Qui aurait l'idée
 de mettre en question le JAR Oracle alors qu'il y a tant de raisons pour
 que notre application ne fonctionne pas ?
 
+[[rebelote_mais_ou_est_javax_jms]]
 ==== Rebelote : mais où est javax.jms ?
 
 Notre problème de dépendance sur le pilote JDBC Oracle est enfin résolu
@@ -4731,6 +4770,7 @@ gratuit et librement diffusable. Chaque bibliothèque introduit des
 contraintes d'utilisation, parfois les restrictions d'une licence
 commerciale, parfois les obligations d'une licence libre.
 
+[[Gerer_son_depot_prive]]
 === Gérer son dépôt privé
 
 Ce qui devait au départ être une tâche de fond pour Carlos se révèle
@@ -4790,6 +4830,7 @@ s'agit pas simplement de pallier les manques du dépôt existant, mais
 aussi de s'assurer de l’unité de notre dépôt et de sa cohérence avec ce
 qui est disponible en ligne.
 
+[[Metadonnees]]
 === Métadonnées
 
 Les choses se compliquent franchement lorsque nous commençons à utiliser
@@ -4817,6 +4858,7 @@ propre version. Voilà un travail bien passionnant qu'il va en plus
 falloir répéter à chaque correction ! Ici aussi, un outillage adéquat
 s'impose.
 
+[[Passer_a_un_veritable_gestionnaire_de_depot]]
 === Passer à un "véritable" gestionnaire de dépôt
 
 image:MangaCarlos.png[float="left"]
@@ -5113,6 +5155,7 @@ Grosse déception : le schéma XML qui dirige la syntaxe du fichier POM ne
 prévoit aucune balise <import>, <include> ou quoi que ce soit
 d'équivalent.
 
+[[Heritage]]
 ==== Héritage
 
 Maven utilise certes un format XML pour l'écriture du POM, format par
@@ -5268,6 +5311,7 @@ nos différentes bibliothèques étaient utilisées dans des versions
 cohérentes sur nos divers sous-projets. Tâche ingrate et pénible, vu le
 nombre impressionnant de dépendances.
 
+[[gestion_des_dependances]]
 ==== Gestion des dépendances
 
 Un élément du fichier POM que nous n'avons pas encore utilisé répond à
@@ -5429,6 +5473,7 @@ SNAPSHOT n'est utilisé en dépendance, ou encore interdire l'utilisation
 de certaines dépendances (par exemple, pour éviter des problèmes de
 licence).
 
+[[Diviser_pour_regner]]
 === Diviser pour régner
 
 image:MangaStephane.png[float="left"]
@@ -5480,6 +5525,7 @@ imagination. Outils de test spécialisés et gestion fine des dépendances
 sont à sa disposition pour forger son module selon ses habitudes et les
 bonnes pratiques du domaine.
 
+[[heritage_naturel]]
 ==== Héritage "naturel"
 
 Les mécanismes de modules et d'héritage ne sont pas nécessairement liés
@@ -5491,6 +5537,7 @@ particulières. La structure hiérarchique des projets est donc une
 structure très courante pour les projets Maven, généralement reflétée
 par l'organisation physique des répertoires.
 
+[[et_l_integration_continue]]
 ==== Et l'intégration continue ?
 
 Comment va se comporter notre serveur d'intégration continue face à ce
@@ -5564,6 +5611,7 @@ par mégarde ! Fini la mauvaise surprise de découvrir un tag JSP qui
 effectue sa propre requête en base pour construire une liste de
 sélection.
 
+[[garder_le_controle]]
 ==== Garder le contrôle
 
 image:MangaStephane.png[float="left"]
@@ -6019,7 +6067,7 @@ Il ne nous reste plus qu'à prendre nos composants et à les grouper dans
 un joli paquet-cadeau avant de l'envoyer à notre hébergeur. En terme
 JavaEE le paquet-cadeau est une archive d'entreprise EAR.
 
-image:MangaVincenTS.png[float="left"]
+image:MangaVincentS.png[float="left"]
 
 Pour produire ce nouvel artefact, Vincent applique la recette qui lui a
 jusqu'ici réussi et fait mouche une nouvelle fois : un nouveau module,
@@ -7012,6 +7060,7 @@ image:09-03.png[align="center"]
 
 Édition de la configuration des plugins.
 
+[[integration_des_plugins_maven]]
 ==== Intégration des plugins Maven
 
 Lors de l'import du projet, m2eclipse lit la configuration de quelques
@@ -7182,6 +7231,7 @@ image:09-08.png[align="center"]
 
 Les dépendances Maven vues sous Idea.
 
+[[integration_des_plugins_maven_2]]
 ==== Intégration des plugins Maven
 
 Les plugins qui génèrent du code lors des premières phases de la
@@ -7309,6 +7359,7 @@ qui regroupe nos bibliothèques). L'assistant propose alors un outil de
 recherche, basé, comme ses concurrents, sur les index mis à disposition
 par les gestionnaires de dépôts.
 
+[[integration_des_plugins_maven_3]]
 ==== Intégration des plugins Maven
 
 NetBeans ne propose pas d'intégration particulière des plugins Maven
@@ -7334,6 +7385,7 @@ image:09-10.png[align="center"]
 
 Intégration de la gestion des dépendances au plus profond de NetBeans.
 
+[[Deliberation_du_jury]]
 === Délibération du jury
 
 La délibération du jury est longue et mouvementée. Riche en arguments,
@@ -7392,8 +7444,10 @@ semaines de développement et de mise au point, notre logiciel est mis à
 la disposition de ses utilisateurs, soumis à leur jugement et à leur
 manque de compassion pour les erreurs que nous aurions pu commettre.
 
+[[Strategie_de_livraison]]
 === Stratégie de livraison
 
+[[Premiere_livraison]]
 ==== Première livraison
 
 image:MangaEmmanuel.png[float="left"]
@@ -7417,6 +7471,7 @@ bouteille pour fêter le succès de notre belle aventure.
 "noubliepaslalistedescourses" est désormais en ligne et attend de pied
 ferme ses utilisateurs.
 
+[[deuxieme_livraison]]
 ==== Deuxième livraison
 
 Une mauvaise surprise nous tombe dessus lorsque nous devons en urgence
@@ -7439,6 +7494,7 @@ jamais nous détections un problème de dernière minute, il nous suffirait
 d'apporter les corrections nécessaires, de poser un nouveau tag et de
 reprendre la procédure.
 
+[[troisieme_livraison]]
 ==== Troisième livraison
 
 Les choses semblent enfin maîtrisées, mais nous déchantons vite quand
@@ -7536,6 +7592,7 @@ documentation pour indiquer la procédure à suivre.
 Pour vous donner une idée de ce que le plugin propose, voici le
 processus qu'il applique pour produire un livrable.
 
+[[etape_1_preparation]]
 ==== Étape 1 : préparation
 
 * Il contrôle l'environnement de l'utilisateur qui ne doit présenter
@@ -7569,6 +7626,7 @@ développer. L'état "version livrée" n'est apparu que furtivement dans
 l'historique du gestionnaire de code source, ce qui correspond bien à la
 réalité de cet événement aussi ponctuel que capital.
 
+[[etape_2_livraison]]
 ==== Étape 2 : livraison
 
 La production du logiciel livrable est réalisée à partir du tag placé
@@ -7615,6 +7673,7 @@ de code source, le temps de bien mettre au point la configuration du
 plugin.
 ====
 
+[[et_si_ca_foire]]
 ==== Et si ça foire ?
 
 La préparation de la livraison comprend de nombreuses étapes et
@@ -7951,6 +8010,7 @@ modifiés, qui permet à tout moment de revenir en arrière en cas de
 fausse manipulation.
 ====
 
+[[Au_dela_de_l_integration_continue]]
 === Au-delà de l'intégration continue
 
 Nous avons déjà mis en œuvre l'automatisation de notre construction de
@@ -8051,6 +8111,7 @@ filiale d'un géant international.
 image:Geegol-Shopping-List.png[float="left"]
 --
 
+[[Utiliser_un_outil_non_supporte]]
 == Chapitre 11 : Utiliser un outil non supporté
 
 Jusqu'ici, nous avons toujours trouvé pour chaque problème que nous
@@ -8089,6 +8150,7 @@ Maven tout prêt pour ce besoin spécifique. Nous sommes le premier projet
 du groupe à utiliser Maven, aussi il va falloir nous remonter les
 manches.
 
+[[reutiliser_l_existant]]
 ==== Réutiliser l'existant
 
 image:MangaHerve.png[float="left"]
@@ -8219,6 +8281,7 @@ immédiatement une nouvelle tâche : l'écriture d'un plugin Maven pour
 notre outil de génération documentaire. C'est donc à cette tâche
 qu'Hervé va s'attaquer à présent.
 
+[[Creer_un_plugin]]
 === Créer un plugin
 
 ==== Pas de panique !
@@ -8304,6 +8367,7 @@ Nous avons donc un projet Maven capable de produire un plugin qui
 exécutera notre code Java lors de la phase process-sources. On vous
 l'avait bien dit que ce n'était pas bien compliqué !
 
+[[des_parametres_pour_le_plugin]]
 ==== Des paramètres pour le plugin
 
 Le plugin d'Hervé est un peu tout seul dans son coin. On doit encore lui
@@ -8357,6 +8421,7 @@ vous encourageons à utiliser ces conventions même si elles ne vous
 plaisent pas complètement.
 ====
 
+[[un_modele_dynamique]]
 ==== Un modèle dynamique
 
 image:MangaHerve.png[float="left"]
@@ -8971,6 +9036,7 @@ sur le sujet n'est pas irréprochable. Les bons exemples ne manquent
 cependant pas et la communauté des développeurs Maven est prête à
 apporter tout le support nécessaire.
 
+[[L_assurance_qualite]]
 == Chapitre 12 : L'assurance qualité
 
 Une application qui fonctionne, c'est bien. Mais du code qui est
@@ -9627,6 +9693,7 @@ courbes : on constate un infléchissement de la courbe dans la semaine
 qui précède la livraison et (dans le meilleur des cas) une reprise lente
 dans les semaines qui suivent.
 
+[[maitrise_de_s]]
 ==== Maîtrise de _S_ footnote:[Petit rappel de vos lointains cours de physique : S est le symbole utilisé en physique pour l’entropie :)]
 
 image:MangaVincentM.png[float="left"]
@@ -9785,6 +9852,7 @@ quoi s'occuper avec ses propres problèmes pour ne pas vouloir se plier à
 nos caprices. À nous de lui fournir un livrable qui colle à ses outils
 et à ses bonnes pratiques pour une mise en production réussie.
 
+[[D_ou_vient_ce_jar]]
 === D'où vient ce JAR ?
 
 Depuis que nous avons mis en place un mécanisme d'intégration continue,
@@ -9831,6 +9899,7 @@ par semaine à l'analyse féroce de nos outils de tests de charge et
 d'interopérabilité. Toutes ces versions portent le même numéro
 1.2.0-SNAPSHOT qui reflète bien que le projet n'est pas encore abouti.
 
+[[numero_de_construction]]
 ==== Numéro de construction
 
 Une solution consiste à produire des binaires dont le numéro de version
@@ -9864,6 +9933,7 @@ les traces d'une construction dont nous livrons le résultat à l'équipe
 de test et de placer une marque dans le gestionnaire de code source en
 conséquence.
 
+[[numero_de_revision]]
 ==== Numéro de révision
 
 Une solution alternative, liée à l'utilisation du gestionnaire de code
@@ -10019,6 +10089,7 @@ suffira de les exploiter pour retrouver rapidement le code source
 associé, et éventuellement les traces de sa construction dans notre
 serveur d'intégration continue.
 
+[[La_confiance_regne]]
 === La confiance règne…
 
 image:MangaStephane.png[float="left"]
@@ -10270,6 +10341,7 @@ C'est au cours de cette exécution qu’il découvrira les constituants de
 chaque projet et identifiera les répertoires de code source (y compris
 le code généré) et les binaires produits.
 
+[[l_integration_continue_produit_notre_livrable]]
 ==== L'intégration continue produit notre livrable
 
 Notre serveur d'intégration continue produit déjà, à intervalles
@@ -10317,6 +10389,7 @@ configuration que nous appliquons.
 Solution miracle ? Eh bien non, échec cuisant. Le plugin assembly plante
 lamentablement en indiquant qu'il ne trouve pas notre EAR :'(.
 
+[[l_oeuf_ou_la_poule]]
 ==== L'œuf ou la poule ?
 
 Quel est le problème ? Il nous faut comprendre un peu mieux les rouages
@@ -10412,6 +10485,7 @@ continue à la production continue, évolution de l'industrie logicielle
 qui n'est pas encore dans les mœurs, mais que Maven peut déjà
 supporter !
 
+[[Un_nouveau_projet_demarre]]
 == Chapitre 14 : Un nouveau projet démarre
 
 Avec tous nos efforts sur notre projet noubliepaslalistedescourses pour
@@ -10551,6 +10625,7 @@ solution : faire un copier-coller dont la phase d'adaptation au nouveau
 projet est automatisée ! Raphaël est en fait tombé sur la description du
 plugin archetype.
 
+[[un_plugin_qui_cree_des_projets]]
 ==== Un plugin qui crée des projets
 
 Pour nous convaincre, il nous fait rapidement une démonstration. Il se
@@ -10662,6 +10737,7 @@ C'est sûr que ce plugin n'est pas très impressionnant pour ce qu'il
 fait, mais tout de même il ne nous aura pas coûté beaucoup d'efforts et
 est totalement fonctionnel. Raphaël enchaîne donc avec l'explication.
 
+[[un_archetype]]
 ==== Un archétype ?
 
 Un archétype est la façon à la Maven de faire de la mutualisation, avec
@@ -10681,6 +10757,7 @@ proposer de reporter dans le modèle soit des corrections qu'elles ont
 faites pour éviter à d'autres de tomber dans les mêmes embûches, soit
 des enrichissements pour capitaliser sur le travail réalisé.
 
+[[construire_ses_propres_archetypes]]
 ==== Construire ses propres archétypes
 
 La structure d'un archétype n'est pas très attirante a priori. Il s'agit
@@ -10720,6 +10797,7 @@ pour être enregistré dans son propre gestionnaire de sources Subversion,
 avec un code fonctionnel qu'il ne restera plus qu'à adapter aux besoins
 spécifiques du nouveau projet.
 
+[[Gerer_un_projet_de_reference]]
 === Gérer un projet de référence
 
 Nous avons donc trouvé une solution très élégante pour repartir d'un
@@ -10735,6 +10813,7 @@ est intéressante pour le nouveau développement, les aspects fonctionnels
 utilitaires seront à reprendre, mais certainement pas les centaines de
 classes que nous avons accumulées depuis le début du projet.
 
+[[donner_le_meilleur_de_nous_meme]]
 ==== Donner le meilleur de nous-mêmes
 
 Le mécanisme extrêmement simple qui permet de créer un archétype
@@ -10755,6 +10834,7 @@ connaîtrait mal, afin de le mettre sur la bonne piste. Le développement
 se faisant beaucoup par imitation, les premières lignes de code
 disponibles sur le projet sont capitales.
 
+[[demarrer_sur_les_bons_rails]]
 ==== Démarrer sur les bons rails
 
 Utilisée comme archétype, notre application blanche met à la disposition
@@ -10790,6 +10870,7 @@ imparfait mais déjà bien plus avancé et intégré que ce qu'il aurait pu
 obtenir en accumulant les conseils et fragments de code piochés à droite
 à gauche.
 
+[[un_support_pour_experimenter]]
 ==== Un support pour expérimenter
 
 Dernier élément, un tel projet peut être fédérateur au sein de
@@ -10850,6 +10931,7 @@ métier basée sur Spring ? L'application blanche met dès le début ces
 questions sur le tapis, y répondre au plus tôt permettra d'introduire
 Flex sur un nouveau projet sans buter sur ces problèmes.
 
+[[un_support_de_demonstration]]
 ==== Un support de démonstration
 
 Pour ceux qui n'ont aucune préférence, l'application blanche lancée en
@@ -10949,7 +11031,7 @@ d'experts qui ne veut pas laisser un si beau projet reposer sur des
 outils non fiables, mal documentés ou dont l'avenir est incertain.
 À nous de nous montrer convaincants…
 
-image:commite.png[float="left"]
+image:comite.png[float="left"]
 
 === Les limites
 
@@ -11149,6 +11231,7 @@ developpez.com héberge un forum francophone consacré à
 Maven footnote:[http://www.developpez.net/forums/f319/java/edi-outils-java/maven/], ainsi qu'une FAQ footnote:[http://java.developpez.com/faq/maven/] bien
 remplie.
 
+[[le_cout_de_maven]]
 ==== Le coût de Maven
 
 image:MangaHerve.png[float="left"]
@@ -11421,6 +11504,7 @@ rapidement des personnes compétentes sur un outil largement utilisé,
 même s'il est imparfait, que de galérer avec un bijou technologique que
 trois personnes au monde savent faire fonctionner.
 
+[[la_communaute]]
 ==== La communauté
 
 image:MangaArnaud.png[float="left"]
@@ -11476,6 +11560,7 @@ peut-être tous tort par rapport à une autre solution parfaite ou
 presque, mais au moins nous pouvons nous serrer les coudes et avancer
 ensemble.
 
+[[l_equipe_de_developpement]]
 ==== L'équipe de développement
 
 Arnaud poursuit en présentant le cœur du projet Apache Maven, ceux qui
@@ -11547,7 +11632,7 @@ gestionnaire du dépôt d'artefacts, serveur d'intégration continue.
 
 === L'avenir de Maven
 
-image:MangaJIM.png[float="left"]
+image:MangaJim.png[float="left"]
 
 Mission impossible ?
 
@@ -11876,6 +11961,7 @@ Figure 15-08
 
 Graven, une création originale d’Arnaud visant à marier Maven et Gradle
 
+[[a_qui_appartient_maven]]
 === À qui appartient Maven ?
 
 Le comité est presque convaincu mais il a tout de même quelques
@@ -11960,6 +12046,7 @@ est bien plus qu’un contributeur de Maven : des composants majeurs de
 Maven 3 ne sont pas développés et hébergés par la fondation Apache, mais
 sous le compte GitHub de Sonatype !
 
+[[un_peu_de_strategie]]
 ==== Un peu de stratégie
 
 Parmi la refonte réalisée pour Maven 3, un élément clé est la réécriture
@@ -12078,7 +12165,7 @@ Le comité nous remercie et s'apprête à délibérer. Nous n'aurons sa
 conclusion qu'après quelques jours (ce sont des gens très occupés) : feu
 vert.
 
-image:commite-feuvert.png[float="left"]
+image:comite-feuvert.png[float="left"]
 
 Maven ne répond pas à toutes les exigences sans quelques efforts, et il
 ne sait pas non plus faire le café. Son utilisation nécessite un
@@ -12117,6 +12204,7 @@ tâche Ant. Il devient délicat de ne pas proposer également un plugin
 Maven, sous peine de crouler sous les réclamations répétées des
 utilisateurs.
 
+[[Au_dela_de_Maven]]
 == Chapitre 16 : Au delà de Maven
 
 Maven nous a accompagné pendant ces 14 chapitres en répondant à chaque
@@ -12612,6 +12700,7 @@ système à partir d’une bibliothèque Java. Bien qu’imbattable sur le
 terrain technique, nous ne voyons pas bien où Mark tente de nous emmener
 avec son projet.
 
+[[a_quoi_ca_sert]]
 ==== A quoi ça sert ?
 
 L’idée de la modularisation est séduisante. Nous avons en effet
@@ -12814,6 +12903,7 @@ Le respect des conventions permet :
 * d'éviter de tomber dans des problèmes ou des bogues qui font
 perdre un temps précieux.
 
+[[commandement_no_2_simplicite_tu_choisiras]]
 ==== Commandement n^o^ 2 : Simplicité tu choisiras.
 
 Notre premier mauvais élève est un projet que nous avons voulu faire
@@ -12869,6 +12959,7 @@ Des projets comme Alfresco ou Liferay ne s'accommodent pas facilement de
 Maven. Il faut prendre le temps d'analyser les besoins et d'organiser au
 mieux le projet pour être efficace.
 
+[[commandement_no_3_au_fur_et_a_mesure_de_tes_besion_les_outils_necessaires_tu_mettras_en_place]]
 ==== Commandement n^o^ 3 : Au fur et à mesure de tes besoins, les outils
 nécessaires tu mettras en place.
 
@@ -12998,6 +13089,7 @@ Bref, les occasions de justifier le découpage d'un module en plusieurs
 modules sont nombreuses. Alors, n'en faites pas plus que nécessaire.
 Vous testerez le réacteur de Maven bien assez tôt.
 
+[[commandement_no_5_tes_outils_et_ton_build_a_jour_tu_maintiendras]]
 ==== Commandement n^o^ 5 : Tes outils et ton build à jour tu maintiendras.
 
 Même si mettre en place l'outillage de développement n'est pas une fin
@@ -13041,6 +13133,7 @@ Les projets durent longtemps et les outils évoluent vite. Les maintenir
 mais qui est finalement vite rentabilisé par les gains de productivité
 de l'équipe.
 
+[[commandement_no_6_dans_un_projet_la_meme_version_tous_les_modules_auront]]
 ==== Commandement n^o^ 6 : Dans un projet, la même version tous les modules
 auront.
 
@@ -13109,6 +13202,7 @@ développement est très réticente à changer cette gestion qui peut avoir
 de lourds impacts sur les projets existants.
 ====
 
+[[commandement_no_8_comme_la_peste_les_dependances_optionnelles_tu_eviteras]]
 ==== Commandement n^o^ 8 : Comme la peste les dépendances optionnelles tu
 éviteras.
 
@@ -13166,6 +13260,7 @@ d'intégration continue a le mérite de ne prendre ni pause ni café. Il
 peut construire pour nous les SNAPSHOT de nos modules au fur et à mesure
 qu'une construction réussie est atteinte.
 
+[[commandement_no_10_l_ide_toujours_tu_privilegieras]]
 ==== Commandement n^o^ 10 : L'IDE toujours tu privilégieras.
 
 Cela fait très expert de scruter la console et de taper à une vitesse
@@ -13274,6 +13369,7 @@ plus simple, ordonné de manière homogène, et qui se plie mieux au mode
 de pensée de Maven. Au final, vos projets n'en seront que plus clairs et
 plus compréhensibles.
 
+[[Epilogue]]
 == Chapitre 18 : Épilogue
 
 Le dernier numéro de Fortune vient de paraître. Dans son grand dossier
@@ -13294,6 +13390,7 @@ projets dans de bonnes conditions, même ceux qui ne sont pas de
 merveilleuses prouesses technologiques ou le sujet d'enjeux
 stratégiques.
 
+[[Recapitulons]]
 === Récapitulons
 
 Bien que quelque peu embellie, l'histoire que nous venons de raconter
@@ -13382,6 +13479,7 @@ commande universelle mvn install !
 Vous vous demandez qui sont ces personnages qui peuplent les pages de ce
 livre ?
 
+[[les_membres_francophones_de_l_equipe_maven]]
 ==== Les membres francophones de l'équipe Maven
 
 Lorsque nous avons décidé de romancer notre ouvrage, nous nous sommes
@@ -13466,6 +13564,7 @@ c'est la protection de l'environnement et la solidarité internationale.
 
 image:MangaHerve.png[float="left"]
 
+[[herve_boutemy]]
 ===== Hervé Boutemy
 
 Hervé Boutemy, j'ai 39 ans, une femme et une fille, et je vis du côté de
@@ -13557,6 +13656,7 @@ du site plugin)
 
 image:MangaRaphael.png[float="left"]
 
+[[raphael_pieroni]]
 ===== Raphaël Piéroni
 
 J'ai 37 ans. J'ai commencé à utiliser Maven 1 en 2002 ou 2003 (je ne me
@@ -13571,6 +13671,7 @@ cas de besoin ;).
 
 image:MangaStephane.png[float="left"]
 
+[[stephane_nicoll]]
 ===== Stéphane Nicoll
 
 J'ai 33 ans depuis peu, je vis dans une région magnifique à l'est de la
@@ -13651,6 +13752,7 @@ Shindig), etc. Mon intérêt pour Maven se situe principalement dans la
 génération de documentation (Doxia avec Lukas !) et les plugins de
 reporting et de QA.
 
+[[les_membres_de_la_communaute_Java]]
 ==== Les membres de la communauté Java
 
 Pour compléter notre fine équipe par quelques profils moins
@@ -13692,6 +13794,7 @@ pour de plus amples informations : http://www.antoniogoncalves.org.
 
 image:MangaFrancois.png[float="left"]
 
+[[francois_le_droff]]
 ===== François Le Droff
 
 Brestois d'origine, parisien d'adoption, j'ai connu le Minitel mais je
@@ -13712,6 +13815,7 @@ technologies Java et Flex (http://www.droff.com).
 
 image:MangaGregory.png[float="left"]
 
+[[gregory_boissinot]]
 ===== Grégory Boissinot
 
 J’ai 30 ans et je travaille depuis 3 ans chez Zenika en tant que
@@ -13766,6 +13870,7 @@ puissant outil de build !
 
 image:MangaJerome.png[float="left"]
 
+[[jerome_van_der_linden]]
 ===== Jérôme Van der Linden
 
 29 ans, architecte JavaEE chez Octo Technology depuis cinq ans, où j'ai
@@ -13797,6 +13902,7 @@ Une de ses principales qualités est son insatiable curiosité.
 
 image:MangaSebastien.png[float="left"]
 
+[[sebastien_le_marechal]]
 ===== Sébastien Le Maréchal
 
 Breton d'origine, je vis actuellement à Casablanca avec ma petite tribu
@@ -13854,6 +13960,7 @@ ensoleille chaque jour ma vie.
 
 image:MangaArnaud.png[float="left"]
 
+[[arnaud_heritier]]
 ===== Arnaud Héritier
 
 Je remercie grandement Nicolas de m'avoir proposé ce challenge. Le
@@ -14118,7 +14225,7 @@ souplesse il est préférable d'installer une véritable application dédiée
 à cette tâche (_Repository Manager_) qui apporte de nombreuses
 fonctionnalités d'administration. Il existe plusieurs serveurs de
 référentiels comme Archiva footnote:[http://archiva.apache.org], Nexus footnote:[http://nexus.sonatype.org],
-Artifactory footnote:[http://www.jfrog.org]...
+Artifactory footnote:[http://artifactory.jfrog.org].
 
 Sisu
 


### PR DESCRIPTION
Bonjour,

Avec la version 8.6.6 d'asciidoc, la compilation du fichier maven.adoc provoquait une erreur.
Cette erreur provenait de la présence de la chaîne de caractères ---- dans les copies de log insérés dans le texte comme du code. En asciidoc, une séquence de quatre - ou plus signifie le début d'un bloc de code. Par conséquent, la présence de la séquence ---- dans les copies de log était comprise comme la fin d'un bloc de code.
Pour remédier à cela, j'ai recopié le fichier de configuration asciidoc.conf, renommé en asciidoc_maven.conf où j'ai redéfini la séquence de début des blocs de code. Il faut maintenant une séquence de 20 - pour signaler le début d'un bloc de code. Pour tenir compte de cette nouvelle configuration, la ligne de commande pour la compilation doit être modifiée. La nouvelle ligne de commande est renseignée dans le fichier README.md.

Cordialement.
